### PR TITLE
Refine layout padding

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -16,7 +16,7 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView,
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-card/95 backdrop-blur-sm border-t border-border z-40">
+    <nav className="sticky top-14 left-0 right-0 bg-card/95 backdrop-blur-sm border-b border-border z-40">
       <div className="flex items-center justify-around h-16 px-4">
         {navItems.map((item) => {
           const Icon = item.icon;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -31,12 +31,12 @@ const Index = () => {
 
   return (
     <ThemeProvider>
-      <div className="min-h-screen bg-background text-foreground transition-colors duration-300 pb-20">
+      <div className="min-h-screen bg-background text-foreground transition-colors duration-300 pt-30">
         <TopHeader />
+        <BottomNavigation currentView={currentView} onViewChange={setCurrentView} />
         <main className="container mx-auto px-4 py-6">
           {renderCurrentView()}
         </main>
-        <BottomNavigation currentView={currentView} onViewChange={setCurrentView} />
         <FloatingAIButton onClick={() => setIsChatOpen(true)} />
         <AIChat isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
       </div>


### PR DESCRIPTION
## Summary
- adjust main content padding to account for sticky top navigation

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f702031a0832c9c3e41652ef423de