### PR TITLE
Integrate AI chat into navigation

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,18 +1,30 @@
 
 import React from 'react';
-import { Bot, FileText, StickyNote, CheckSquare } from 'lucide-react';
+import {
+  Bot,
+  FileText,
+  StickyNote,
+  CheckSquare,
+  LayoutDashboard
+} from 'lucide-react';
 
 interface BottomNavigationProps {
   currentView: string;
   onViewChange: (view: string) => void;
+  onChatOpen: () => void;
 }
 
-export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView, onViewChange }) => {
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({
+  currentView,
+  onViewChange,
+  onChatOpen
+}) => {
   const navItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: Bot },
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'prompts', label: 'Prompts', icon: FileText },
     { id: 'notes', label: 'Notes', icon: StickyNote },
     { id: 'tasks', label: 'Tasks', icon: CheckSquare },
+    { id: 'chat', label: 'AI Chat', icon: Bot }
   ];
 
   return (
@@ -24,7 +36,9 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView,
           return (
             <button
               key={item.id}
-              onClick={() => onViewChange(item.id)}
+              onClick={() =>
+                item.id === 'chat' ? onChatOpen() : onViewChange(item.id)
+              }
               className={`flex flex-col items-center justify-center space-y-1 min-w-0 flex-1 py-2 transition-colors duration-200 ${
                 isActive 
                   ? 'text-primary' 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,22 +1,37 @@
 
 import React from 'react';
-import { User, Bot, FileText, StickyNote, CheckSquare, Sun, Moon } from 'lucide-react';
+import {
+  User,
+  Bot,
+  FileText,
+  StickyNote,
+  CheckSquare,
+  LayoutDashboard,
+  Sun,
+  Moon
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/components/ThemeProvider';
 
 interface NavigationProps {
   currentView: string;
   onViewChange: (view: string) => void;
+  onChatOpen: () => void;
 }
 
-export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChange }) => {
+export const Navigation: React.FC<NavigationProps> = ({
+  currentView,
+  onViewChange,
+  onChatOpen
+}) => {
   const { theme, toggleTheme } = useTheme();
 
   const navItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: Bot },
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { id: 'prompts', label: 'Prompts', icon: FileText },
     { id: 'notes', label: 'Notes', icon: StickyNote },
     { id: 'tasks', label: 'Tasks', icon: CheckSquare },
+    { id: 'chat', label: 'AI Chat', icon: Bot }
   ];
 
   return (
@@ -35,7 +50,9 @@ export const Navigation: React.FC<NavigationProps> = ({ currentView, onViewChang
                   <Button
                     key={item.id}
                     variant={currentView === item.id ? 'default' : 'ghost'}
-                    onClick={() => onViewChange(item.id)}
+                    onClick={() =>
+                      item.id === 'chat' ? onChatOpen() : onViewChange(item.id)
+                    }
                     className="flex items-center space-x-2"
                   >
                     <Icon className="h-4 w-4" />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,6 @@ import { PromptsView } from '@/components/PromptsView';
 import { NotesView } from '@/components/NotesView';
 import { TasksView } from '@/components/TasksView';
 import { AIChat } from '@/components/AIChat';
-import { FloatingAIButton } from '@/components/FloatingAIButton';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { BottomNavigation } from '@/components/BottomNavigation';
 import { TopHeader } from '@/components/TopHeader';
@@ -31,14 +30,17 @@ const Index = () => {
 
   return (
     <ThemeProvider>
-      <div className="min-h-screen bg-background text-foreground transition-colors duration-300 pt-30">
-        <TopHeader />
-        <BottomNavigation currentView={currentView} onViewChange={setCurrentView} />
-        <main className="container mx-auto px-4 py-6">
-          {renderCurrentView()}
-        </main>
-        <FloatingAIButton onClick={() => setIsChatOpen(true)} />
-        <AIChat isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
+        <div className="min-h-screen bg-background text-foreground transition-colors duration-300 pt-30">
+          <TopHeader />
+          <BottomNavigation
+            currentView={currentView}
+            onViewChange={setCurrentView}
+            onChatOpen={() => setIsChatOpen(true)}
+          />
+          <main className="container mx-auto px-4 py-6">
+            {renderCurrentView()}
+          </main>
+          <AIChat isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
       </div>
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary
- integrate LayoutDashboard and Bot icons in navigation menus
- add new AI Chat item in both navigation components
- trigger AI chat from navigation instead of floating button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841f3ce77c4832c8827a8308c6da699