### PR TITLE
Move AI chat into navigation

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,18 +1,21 @@
 
 import React from 'react';
-import { Bot, FileText, StickyNote, CheckSquare } from 'lucide-react';
+import { Bot, FileText, StickyNote, CheckSquare, MessageCircle } from 'lucide-react';
 
 interface BottomNavigationProps {
   currentView: string;
   onViewChange: (view: string) => void;
+  onChatOpen: () => void;
+  isChatOpen: boolean;
 }
 
-export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView, onViewChange }) => {
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView, onViewChange, onChatOpen, isChatOpen }) => {
   const navItems = [
     { id: 'dashboard', label: 'Dashboard', icon: Bot },
     { id: 'prompts', label: 'Prompts', icon: FileText },
     { id: 'notes', label: 'Notes', icon: StickyNote },
     { id: 'tasks', label: 'Tasks', icon: CheckSquare },
+    { id: 'chat', label: 'AI Chat', icon: MessageCircle },
   ];
 
   return (
@@ -20,21 +23,26 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({ currentView,
       <div className="flex items-center justify-around h-16 px-4">
         {navItems.map((item) => {
           const Icon = item.icon;
-          const isActive = currentView === item.id;
+          const isActive = item.id === 'chat' ? isChatOpen : currentView === item.id;
+          const handleClick = () => {
+            if (item.id === 'chat') {
+              onChatOpen();
+            } else {
+              onViewChange(item.id);
+            }
+          };
           return (
             <button
               key={item.id}
-              onClick={() => onViewChange(item.id)}
+              onClick={handleClick}
               className={`flex flex-col items-center justify-center space-y-1 min-w-0 flex-1 py-2 transition-colors duration-200 ${
-                isActive 
-                  ? 'text-primary' 
+                isActive
+                  ? 'text-primary'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               <Icon className={`h-5 w-5 ${isActive ? 'scale-110' : ''} transition-transform duration-200`} />
-              <span className={`text-xs font-medium ${isActive ? 'text-primary' : ''}`}>
-                {item.label}
-              </span>
+              <span className={`text-xs font-medium ${isActive ? 'text-primary' : ''}`}>{item.label}</span>
             </button>
           );
         })}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,7 +5,6 @@ import { PromptsView } from '@/components/PromptsView';
 import { NotesView } from '@/components/NotesView';
 import { TasksView } from '@/components/TasksView';
 import { AIChat } from '@/components/AIChat';
-import { FloatingAIButton } from '@/components/FloatingAIButton';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { BottomNavigation } from '@/components/BottomNavigation';
 import { TopHeader } from '@/components/TopHeader';
@@ -33,11 +32,15 @@ const Index = () => {
     <ThemeProvider>
       <div className="min-h-screen bg-background text-foreground transition-colors duration-300 pt-30">
         <TopHeader />
-        <BottomNavigation currentView={currentView} onViewChange={setCurrentView} />
+        <BottomNavigation
+          currentView={currentView}
+          onViewChange={setCurrentView}
+          onChatOpen={() => setIsChatOpen(true)}
+          isChatOpen={isChatOpen}
+        />
         <main className="container mx-auto px-4 py-6">
           {renderCurrentView()}
         </main>
-        <FloatingAIButton onClick={() => setIsChatOpen(true)} />
         <AIChat isOpen={isChatOpen} onClose={() => setIsChatOpen(false)} />
       </div>
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- add AI Chat item to the navigation bar
- wire up navigation item to open chat dialog
- remove floating AI button in the main page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841f74ed7f8832c96a166507258e74c